### PR TITLE
Unify format v3: defaults/permalink update

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,3 +37,12 @@ kramdown:
 url: "https://itdojp.github.io"
 baseurl: "/formal-methods-book"
 repository: "itdojp/formal-methods-book"
+# Defaults: use custom book layout as default
+defaults:
+  - scope:
+      path: ""
+      type: "pages"
+    values:
+      layout: "book"
+
+permalink: pretty


### PR DESCRIPTION
タイトル: Unify format v3: defaults/permalink update

概要:
- `_config.yml` に `defaults: layout: book` と `permalink: pretty` を設定（該当箇所のみ）
- サイト構成や既存レイアウトは維持しつつ、Jekyll のデフォルトレイアウトとパーマリンクを統一

変更点:
- docs/_config.yml: defaults 追加または修正
- docs/_config.yml: permalink を `pretty` に設定

確認事項:
- [ ] `bundle exec jekyll build` または Pages ビルド成功
- [ ] 主要ページ（トップ/章）のURLが `.../page/` 形式で表示される
- [ ] サイドバー「📚 リソース」の表示とリンクの動作

関連:
- 統一ガイド: https://github.com/itdojp/book-formatter/blob/main/docs/book-format-unification-guide.md
- トラッキング: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/21