### PR TITLE
docs: add bottom navigation to root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,3 +99,5 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 **バージョン:** 1.0.0  
 **最終更新:** 2025-07-28  
 **GitHub Pages:** 自動デプロイ対応
+
+{% include page-navigation.html %}


### PR DESCRIPTION
Add bottom navigation include to docs/index.md so the root page shows prev/next/home controls.