### PR TITLE
fix(stage2): 第12章の節番号重複を解消

### DIFF
--- a/docs/chapters/chapter12/index.md
+++ b/docs/chapters/chapter12/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第12章：ツールと自動化"
+title: "第12章　ツールと自動化"
 chapter: chapter12
 order: 12
 ---


### PR DESCRIPTION
## 背景
`docs/chapters/chapter12/index.md` で、`## 12.3` と `## 12.4` が重複していました。

## 対応
- 12.5〜12.8 に連番として振り直し（内容は変更なし）

## 影響
- 章内の見出し番号の一貫性を改善（目次生成や参照での混乱を回避）
