### PR TITLE
fix: 章タイトル（front matter）を見出しに整合（第1〜11章）

### DIFF
--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第1章：なぜ形式的手法が必要なのか"
+title: "第1章　なぜ形式的手法が必要なのか"
 nav_order: 1
 ---
 

--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第2章：数学とプログラムの橋渡し"
+title: "第2章　数学とプログラムの橋渡し"
 nav_order: 2
 ---
 

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第3章：仕様記述の基本"
+title: "第3章　仕様記述の基本"
 chapter: chapter03
 order: 3
 ---

--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第4章：軽量形式的手法入門 - Alloyで始める仕様記述"
+title: "第4章　軽量形式的手法入門 - Alloyで始める仕様記述"
 nav_order: 4
 ---
 

--- a/docs/chapters/chapter05/index.md
+++ b/docs/chapters/chapter05/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第5章：状態ベース仕様記述 - Z記法の基礎"
+title: "第5章　状態ベース仕様記述 - Z記法の基礎"
 chapter: chapter05
 order: 5
 ---

--- a/docs/chapters/chapter06/index.md
+++ b/docs/chapters/chapter06/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第6章：プロセス中心の記述 - CSPによる並行システム"
+title: "第6章　プロセス中心の記述 - CSPによる並行システム"
 chapter: chapter06
 order: 6
 ---

--- a/docs/chapters/chapter07/index.md
+++ b/docs/chapters/chapter07/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第7章：時間を扱う仕様記述 - TLA+入門"
+title: "第7章　時間を扱う仕様記述 - TLA+入門"
 chapter: chapter07
 order: 7
 ---

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第8章：模型検査入門"
+title: "第8章　模型検査入門"
 chapter: chapter08
 order: 8
 ---

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第9章：定理証明の基礎"
+title: "第9章　定理証明の基礎"
 chapter: chapter09
 order: 9
 ---

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第10章：プログラム検証"
+title: "第10章　プログラム検証"
 chapter: chapter10
 order: 10
 ---

--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-title: "第11章：開発プロセスとの統合"
+title: "第11章　開発プロセスとの統合"
 chapter: chapter11
 order: 11
 ---


### PR DESCRIPTION
目的: ページタイトル/ナビ表示の一貫性向上（初心者の迷子防止）。

対応内容:
- `docs/chapters/chapter01〜11/index.md` の front matter `title` を本文先頭の見出し（`# 第N章　...`）に合わせ、`第N章：...` → `第N章　...` に統一

補足:
- 第12章は別PR（#96）が編集中のため本PRから除外
- 第13章は別PR（#93）が編集中のため本PRから除外