### PR TITLE
Fix: ナビゲーション/フォーマット統一（#55 #57）

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -2,6 +2,7 @@
 introduction:
   - title: "はじめに"
     path: "/introduction/"
+    order: 0
 
 # 本編 (Main chapters)
 chapters:
@@ -49,16 +50,22 @@ chapters:
 appendices:
   - title: "付録A: 数学的基礎の復習"
     path: "/appendices/appendix-a/"
+    order: 14
   - title: "付録B: ツールインストールガイド"
     path: "/appendices/appendix-b/"
+    order: 15
   - title: "付録C: 記法対照表"
     path: "/appendices/appendix-c/"
+    order: 16
   - title: "付録D: 演習問題解答"
     path: "/appendices/appendix-d/"
+    order: 17
   - title: "付録E: 参考文献とWebリソース"
     path: "/appendices/appendix-e/"
+    order: 18
 
-# リソース (Resources)
-resources:
+# あとがき (Afterword)
+afterword:
   - title: "あとがき"
     path: "/afterword/"
+    order: 19

--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -88,7 +88,8 @@
                     </svg>
                 </button>
                 
-                <a href="{{ site.repository.github | default: '#' }}" class="github-link" target="_blank" rel="noopener" aria-label="View on GitHub">
+                {% assign repository = site.repository | replace: "https://github.com/", "" %}
+                <a href="https://github.com/{{ repository }}" class="github-link" target="_blank" rel="noopener" aria-label="View on GitHub">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
@@ -119,9 +120,15 @@
                 {% endif %}
 
                 <!-- Edit on GitHub -->
-                {% if site.repository.github and page.path %}
+                {% if site.repository and page.path %}
                 <div class="edit-page">
-                    <a href="{{ site.repository.github }}/edit/main/{{ page.path }}" 
+                    {% assign repository = site.repository | replace: "https://github.com/", "" %}
+                    {% assign edit_path = page.path %}
+                    {% assign edit_prefix = edit_path | slice: 0, 5 %}
+                    {% if edit_prefix != "docs/" %}
+                      {% assign edit_path = "docs/" | append: edit_path %}
+                    {% endif %}
+                    <a href="https://github.com/{{ repository }}/edit/main/{{ edit_path }}" 
                        target="_blank" 
                        rel="noopener"
                        class="edit-link">


### PR DESCRIPTION
Closes #55
Closes #57

## 変更内容
- `docs/_data/navigation.yml` の `afterword` セクションを正規化（`resources` から移動）し、章→付録→あとがき の順で前へ/次へが辿れるように整理。
- `order` を introduction/appendices/afterword に付与（フォールバック時の順序安定化）。
- `docs/_layouts/book.html` の GitHubリンク/編集リンクを `site.repository` 前提に統一し、`/docs/` 配下を編集対象として正しく指すように修正。
