### PR TITLE
P2: 付録A/Cへの導線を各章に追加

### DIFF
--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -10,6 +10,7 @@ nav_order: 1
 - 複雑性の爆発と創発的振る舞いの課題
 - 数学的モデル化・検証で信頼性を高める
 - 安全/セキュリティ/規制に応える基盤を整える
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 1.1 ソフトウェアの複雑化と信頼性への挑戦

--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -10,6 +10,7 @@ nav_order: 2
 - プログラミングに潜む数学構造の明示化
 - 仕様記述（第4–7章）への橋渡し
 - 図2-3で主要手法の比較観点を把握
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 2.1 プログラミングに潜む数学的構造

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -11,6 +11,7 @@ order: 3
 - 自然言語の曖昧性を克服する
 - 仕様の階層性/多面性を整理
 - UML↔形式仕様の往復（図3-3）で精度/速度両立
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 3.1 仕様とは何か：理想と現実の架け橋

--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -10,6 +10,7 @@ nav_order: 4
 - 関係中心モデリングで構造整合を迅速検査
 - 小スコープ反例で短サイクル改善
 - 図4-1/図8-1/図10-1で検証レベルを設計
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 4.1 Alloyの哲学：軽量だが強力なアプローチ

--- a/docs/chapters/chapter05/index.md
+++ b/docs/chapters/chapter05/index.md
@@ -11,6 +11,7 @@ order: 5
 - 状態/操作スキーマで事前/事後と不変を統合
 - 合成で性質を保全し実装整合を図る
 - 図5-1と第10章の往復で検証可能性を設計
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 5.1 Z記法の世界：状態とスキーマの思想

--- a/docs/chapters/chapter06/index.md
+++ b/docs/chapters/chapter06/index.md
@@ -11,6 +11,7 @@ order: 6
 - プロセス代数・チャネルで並行/同期を表現
 - 図6-1の観点でデッドロック/進行性を分析
 - 図11-1/図10-1と連携しDevOps/検証層へ展開
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 6.1 並行性の本質：なぜ難しいのか

--- a/docs/chapters/chapter07/index.md
+++ b/docs/chapters/chapter07/index.md
@@ -11,6 +11,7 @@ order: 7
 - 時相論理で安全性/活性・公正性を記述
 - 仕様→反例→改善のループを確立
 - 第6/11/12章と連携して分散に適用
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 7.1 分散システムの挑戦：時間と状態の複雑さ

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -11,6 +11,7 @@ order: 8
 - 仕様と性質を分離し自動探索・反例学習
 - 境界づけ/抽象化でスケール
 - 図8-1・第12章に沿って段階別に深度UP
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 8.1 自動検証の夢：コンピュータによる証明

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -11,6 +11,7 @@ order: 9
 - 型理論に基づく証明支援で厳密性を確保
 - 反例の補題化・一般化で保証を強化
 - 第8/10/12章と往復して実務に適用
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 9.1 証明の機械化：数学者とコンピュータの協調

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -11,6 +11,7 @@ order: 10
 - Hoare論理で部分/全正しさを保証
 - 仕様↔実装の整合を担保
 - 図10-1・第11/12章で層/CIを設計
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 10.1 プログラムの正しさ：理論と実践の結節点

--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -11,6 +11,7 @@ order: 11
 - 選択的形式化と段階導入で実務に接続
 - PR/夜間/リリース前の検証配置と反例運用
 - KPIで継続的改善（図11-1・第12章）
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 11.1 現実との調和：理想と制約のバランス

--- a/docs/chapters/chapter12/index.md
+++ b/docs/chapters/chapter12/index.md
@@ -11,6 +11,7 @@ order: 12
 - 検証をツールチェーン/CIへ統合
 - 反例最小化・分割/再実行で運用安定
 - 段階別深度とメトリクス（図11-1/10-1）
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 12.1 ツールエコシステムの全体像

--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -11,6 +11,7 @@ order: 13
 - 事例の文脈/制約/成果を多面的に分析
 - 適用判断表/失敗パターンから学びを一般化
 - 図2-3/3-3/10-1/11-1で導入戦略を設計
+- 戻り先: [付録A（数学的基礎）]({{ '/appendices/appendix-a/' | relative_url }}) / [付録C（記法対照）]({{ '/appendices/appendix-c/' | relative_url }})
 - 用語の確認: [用語集]({{ '/glossary/' | relative_url }})
 
 ## 13.1 事例研究の方法論：成功と失敗から学ぶ


### PR DESCRIPTION
Refs: #116\n\n対応内容\n- 各章（1〜13）のミニ要約に、戻り先として付録A（数学的基礎）/付録C（記法対照）へのリンクを追加。\n\n確認\n- 
> formal-methods-book@1.0.0 test
> npm run lint && npm run check-links


> formal-methods-book@1.0.0 lint
> markdownlint 'src/**/*.md' --ignore src/appendices/appendices_draft.md


> formal-methods-book@1.0.0 check-links
> markdown-link-check -q -p src/chapters/*.md && markdown-link-check -q -p src/appendices/appendix-*.md && markdown-link-check -q -p src/introduction/index.md && markdown-link-check -q -p src/afterword/index.md\n