### PR TITLE
fix: Afterword を形式的手法の内容へ差し替え

### DIFF
--- a/docs/afterword/index.md
+++ b/docs/afterword/index.md
@@ -35,7 +35,7 @@ AIによる生成や改修が高速化するほど、最終判断は検証器に
 
 - 付録E（参考文献とWebリソース）：https://itdojp.github.io/formal-methods-book/appendices/appendix-e/
 - 第12章（ツールと自動化）：https://itdojp.github.io/formal-methods-book/chapters/chapter12/
-- Issue（誤植/改善提案）：https://github.com/itdojp/formal-methods-book/issues
+- フィードバック（誤植/改善提案）：knowledge@itdo.jp
 
 本書が、実務における検証文化の土台づくりに役立つことを願っています。
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node scripts/build.js",
     "test": "npm run lint && npm run check-links",
     "lint": "markdownlint 'src/**/*.md' --ignore src/appendices/appendices_draft.md",
-    "check-links": "markdown-link-check -q -p src/chapters/*.md && markdown-link-check -q -p src/appendices/appendix-*.md && markdown-link-check -q -p src/introduction/index.md && markdown-link-check -q -p src/afterword/index.md",
+    "check-links": "markdown-link-check -q -p src/chapters/*.md && markdown-link-check -q -p src/appendices/appendix-*.md && markdown-link-check -q -p src/introduction/index.md && markdown-link-check -q -p src/afterword/index.md && markdown-link-check -q -p docs/afterword/index.md",
     "deploy": "gh-pages -d docs"
   },
   "keywords": [


### PR DESCRIPTION
対象ページ: https://itdojp.github.io/formal-methods-book/afterword/

現状、GitHub Pages（main /docs）で公開されているあとがきが別書籍（ITインフラ系）の内容になっていたため、本書向けに差し替えました。

変更
- docs/afterword/index.md: 本書『形式的手法の基礎と応用』のあとがきへ差し替え（フィードバック窓口はメールアドレスへ）
- package.json: `check-links` に `docs/afterword/index.md` を追加（公開ページ側のリンクも検証）

確認
- `NODE_OPTIONS=--no-network-family-autoselection npm test`
