### PR TITLE
chore: add book QA workflow (unicode + links)

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Unicode check (fail on warnings)
-        run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --fail-on warn
+        run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
 
       - name: Link check (internal + anchors)
         run: node book-formatter/scripts/check-links.js "${{ steps.scan.outputs.dir }}"


### PR DESCRIPTION
Issue: itdojp/it-engineer-knowledge-architecture#102\n\n- book-formatter の unicode/link チェックを PR/Push で実行します。\n- Unicode は warnings も Fail（--fail-on warn）としてブロックします。\n- link は内部リンク/アンカーのみを Fail とします（外部リンクはチェックしません）。\n- book-formatter はコミット e0fb33d224f368d7ce1830401e88e7e29053fb8e に pin しています。