### PR TITLE
docs: update Dockerfile examples to Ubuntu 24.04

### DIFF
--- a/docs/src/chapters/chapter08/index.md
+++ b/docs/src/chapters/chapter08/index.md
@@ -1224,7 +1224,7 @@ docker exec nginx-2 cat /etc/nginx/nginx.conf
 # レイヤー数を最小化するDockerfile例
 
 # 悪い例（レイヤー数が多い）
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update
 RUN apt-get install -y nginx
 RUN apt-get install -y curl
@@ -1232,7 +1232,7 @@ RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
 # 良い例（レイヤー数を最小化）
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get install -y nginx curl && \
     apt-get clean && \


### PR DESCRIPTION
## 変更内容\n- Dockerfile例のベースイメージを Ubuntu 24.04 に更新（20.04を削除）\n\n## 背景\n- 『20.04向け手順は削除して22.04/24.04のみ残す』方針に合わせる。\n\n## 影響範囲\n- ドキュメント記述のみ\n\n## 確認\n- Book QA/CI にて確認