### PR TITLE
docs: replace Ubuntu 20.04 examples

### DIFF
--- a/manuscript/chapters/chapter08/index.md
+++ b/manuscript/chapters/chapter08/index.md
@@ -1224,7 +1224,7 @@ docker exec nginx-2 cat /etc/nginx/nginx.conf
 # レイヤー数を最小化するDockerfile例
 
 # 悪い例（レイヤー数が多い）
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update
 RUN apt-get install -y nginx
 RUN apt-get install -y curl
@@ -1232,7 +1232,7 @@ RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
 # 良い例（レイヤー数を最小化）
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get install -y nginx curl && \
     apt-get clean && \


### PR DESCRIPTION
方針「20.04向け手順は削除して22.04/24.04のみ残す」に合わせ、本文中の Dockerfile 例を更新します。

- 対象: `manuscript/chapters/chapter08/index.md`
- 変更: `FROM ubuntu:20.04` -> `FROM ubuntu:24.04`

注: 手順自体はレイヤー最適化の説明を維持しつつ、EOL 版の例を除去する目的です。
