### PR TITLE
fix(docs): update Node.js prerequisite

### DIFF
--- a/HANDOVER-SUMMARY.md
+++ b/HANDOVER-SUMMARY.md
@@ -53,7 +53,7 @@ https://github.com/itdojp/book-publishing-template
 }
 
 // 開発環境
-Node.js 18+, GitHub CLI認証済み
+Node.js 20+, GitHub CLI認証済み
 権限: itdojp organization maintain
 ```
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -169,7 +169,7 @@ v2.0テンプレートの使用を強く推奨します
 ### 前提条件
 ```bash
 # 必要なツール
-- Node.js 18+
+- Node.js 20+
 - Git
 - GitHub CLI (gh)
 - 適切なGitHub権限（itdojp organizationのmaintain権限）
@@ -238,7 +238,7 @@ gh pr create --title "Add new feature" --body "Description"
 #### 1. セットアップエラー
 ```bash
 # 症状: easy-setup.js実行時のエラー
-# 解決: Node.js 18以上の確認、権限確認
+# 解決: Node.js 20以上の確認、権限確認
 
 # デバッグコマンド
 node --version

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## セットアップとビルド
 
-- 依存（任意）: Node.js 18+
+- 依存（任意）: Node.js 20+
 - ビルド: `npm run build`
   - `src/appendices/*` を `docs/appendices/<id>/index.md` にコピーします。
   - 章（`docs/chapters/*`）は Jekyll フロントマターを含むため本ビルダーでは変更しません。


### PR DESCRIPTION
## 変更内容
- Node.js 前提の記載を更新
  - Node.js 18+ / 18以上 → 20+ / 20以上（README/HANDOVER 系）

## 背景
- Node.js 18 はサポート終了（EOL）のため、前提条件の記載を更新します。

## 影響範囲
- ドキュメントのみ（本文/ビルド設定/CI 変更なし）
