### PR TITLE
図表・テンプレート例の GitHub Actions バージョンを v4 に更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Local tool outputs and caches
+.artifacts/
+_apalache-out/
+tools/.cache/
+tools/.tmp/
+
+# Common local dependencies
+node_modules/
+
+# OS/editor noise
+.DS_Store

--- a/book-template-guide.md
+++ b/book-template-guide.md
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
 

--- a/docs/assets/images/diagrams/devops-formal-verification-pipeline.svg
+++ b/docs/assets/images/diagrams/devops-formal-verification-pipeline.svg
@@ -90,7 +90,7 @@
     <text x="110" y="295" class="code-text">  verify:</text>
     <text x="110" y="310" class="code-text">    runs-on: ubuntu-latest</text>
     <text x="110" y="325" class="code-text">    steps:</text>
-    <text x="120" y="340" class="code-text">    - uses: actions/checkout@v3</text>
+    <text x="120" y="340" class="code-text">    - uses: actions/checkout@v4</text>
     <text x="120" y="355" class="code-text">    - name: Run Alloy Analysis</text>
     <text x="130" y="370" class="code-text">      run: java -jar alloy.jar model.als</text>
   </g>


### PR DESCRIPTION
Issue #102 の残作業（非推奨記述の棚卸し）対応です。

- `book-template-guide.md` の Actions 記述を `@v4` に更新
  - `actions/checkout@v3` -> `actions/checkout@v4`
  - `actions/setup-node@v3` -> `actions/setup-node@v4`
- 図表 `docs/assets/images/diagrams/devops-formal-verification-pipeline.svg` の表記を `@v4` に更新
- 生成物混入防止のため `.gitignore` を追加
  - `.artifacts/`, `_apalache-out/`, `tools/.cache/`, `tools/.tmp/`, `node_modules/` など
