### PR TITLE
docs: fix layout-risk long code lines in chapter10

### DIFF
--- a/docs/src/chapters/chapter10/index.md
+++ b/docs/src/chapters/chapter10/index.md
@@ -1610,6 +1610,8 @@ reference-config-file: /etc/suricata/reference.config
 ```bash
 # /etc/suricata/rules/local.rules
 # 高精度検知ルールの例
+# NOTE: 以下のルールは可読性のために行継続記号「\」で改行しています。
+# 実運用で local.rules に適用する際は、各ルールを1行に戻してください。
 
 # SQL インジェクション検知（偽陽性を減らす）
 alert http $EXTERNAL_NET any -> $HTTP_SERVERS $HTTP_PORTS \


### PR DESCRIPTION
## 概要
- `docs/src/chapters/chapter10/index.md` の Suricata ルール例で、layout risk scan の `long_code_line` warning が4件出ていたため、行長を短くする調整を行いました。
- 記述内容（ルールの意味）は変更せず、可読性を保ったまま折り返しのみ実施しています。

## 対応内容
- 長いルール行をバックスラッシュ継続で複数行に分割
- 対象 warning: `long_code_line` 4件（すべて解消）

## 確認
- `node ../book-formatter/scripts/check-layout-risk.js docs --fail-on none --output /home/devuser/work/CodeX/booksB/tmp_layout_formal-methods-book_20260212_after_wrap.json`
  - warnings=0, errors=0
- `node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on warn`
  - warnings=0, errors=0
- `node ../book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn`
  - warnings=0, errors=0
- `node ../book-formatter/scripts/check-textlint.js docs --fail-on error`
  - errors=0
- `node ../book-formatter/scripts/check-links.js docs`
  - brokenLinks=0
