### PR TITLE
fix: 第4章の混入フェンス（text）を除去

### DIFF
--- a/src/chapters/chapter04.md
+++ b/src/chapters/chapter04.md
@@ -556,9 +556,6 @@ check HighestIdWins for 5 Node, 10 Message, 8 Time
 ```
 
 これらの実例は、第8章の模型検査や第11章の開発プロセス統合で再び参照され、Alloyモデルの実用的価値を具体的に示しています。
-    all x: Contact | x.friends.t' = x.friends.t
-}
-```text
 
 ### 複数のシグネチャ間の関係
 


### PR DESCRIPTION
- 第4章に混入していた不要な行（Contact関連の断片 + ` ```text` の開始行）を除去
- これにより、後続の ` ```alloy` ブロックがコードフェンス内にネストしてレンダリング崩れする問題を解消
