### PR TITLE
Drawer（TOC）: 現在位置を自動スクロール（Pages main向け）

### DIFF
--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -304,10 +304,17 @@
                     scheduleEnsure();
                 });
 
-                // If the drawer is already open (bfcache/restore), ensure once.
+                // If the drawer is already open on initial load, ensure once.
                 if (cb.checked) {
                     scheduleEnsure();
                 }
+
+                // BFCache restore: DOMContentLoaded won't re-fire, and there may be no `change` event.
+                window.addEventListener('pageshow', function(e) {
+                    if (!e || !e.persisted) return;
+                    if (!cb.checked) return;
+                    scheduleEnsure();
+                });
             }
 
             if (document.readyState === 'loading') {


### PR DESCRIPTION
## 目的
GitHub Pages の公開元が `main`（`/docs`）になっているため、Drawer（TOC）を開いた際に現在位置（`.toc-link.active`）を自動スクロールして可視化する処理を `main` に適用します。

※ 既存のロールアウトPR（#170）はベースブランチが `diagram-enhancement-phase6` のため、公開サイト（GitHub Pages）には反映されません。

## 変更内容
- `docs/_layouts/book.html` に、Drawer open 時に `.toc-link.active` を `scrollIntoView` するスクリプトを追加
  - モバイル幅のみ（`max-width: 1024px`）
  - CSSトランジション/フォーカス等の影響を考慮し 0ms + 350ms の二段実行

## 関連
- it-engineer-knowledge-architecture Issue #117（Pages Visual Check の warn 対応）
- it-engineer-knowledge-architecture Issue #122（同事象の検出/改善）
