### PR TITLE
Fix #194: Alloy閉包の修正 + ラベル整合 + 構造lint導線

### DIFF
--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -204,19 +204,19 @@ Alloyでは、関係に対する豊富な演算が提供されています：
 
 **結合（join）**: `r.s` - 関係rとsを結合
 **転置（transpose）**: `~r` - 関係rの方向を逆転
-**反射推移閉包**: `^r` - 関係rの推移閉包
-**推移閉包**: `*r` - 関係rの反射推移閉包
+**推移閉包**: `^r` - 関係rの推移閉包（1回以上）
+**反射推移閉包**: `*r` - 関係rの反射推移閉包（0回以上）
 
 例：
 【ツール準拠（そのまま動く）】
 ```text
-// すべての祖先
+// すべての祖先（自分自身を除く）
 person.^parent
 
 // 相互フォロー関係
 person.follows & person.~follows
 
-// 到達可能なすべてのファイル
+// 到達可能なすべての子孫（自分自身を含む）
 directory.*children
 ```
 
@@ -404,7 +404,12 @@ pred canReadEmail[u: User, e: Email] {
 // セキュリティ検証のアサーション
 assert NoUnauthorizedAccess {
     all u: User, e: Email |
-        canReadEmail[u, e] or not (u can read e)
+        some e.confidential and
+        u != e.sender and u not in e.recipients and
+        u != e.confidential and
+        AdminAccess not in u.roles.permissions
+        implies
+        not canReadEmail[u, e]
 }
 
 check NoUnauthorizedAccess for 5 User, 5 Email, 3 Role

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -110,12 +110,17 @@ order: 8
 
 第4章で学習したAlloyモデリングは、模型検査の優れた入門となります。Alloyの`check`コマンドは、本質的に小規模な模型検査を実行しています：
 
-【ツール準拠（そのまま動く）】
+【擬似記法】（第4章のモデル定義を省略しているため、そのまま実行できません）
 ```alloy
 // 第4章の電子メールシステム例の再検討
 assert NoUnauthorizedAccess {
     all u: User, e: Email |
-        canReadEmail[u, e] or not (u can access e)
+        some e.confidential and
+        u != e.sender and u not in e.recipients and
+        u != e.confidential and
+        AdminAccess not in u.roles.permissions
+        implies
+        not canReadEmail[u, e]
 }
 check NoUnauthorizedAccess for 5 User, 5 Email, 3 Role
 ```

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "start": "npm run build && npx http-server docs -p 4321 -c-1",
     "build": "node scripts/build.js",
-    "test": "npm run lint && npm run check-links",
+    "test": "npm run lint && npm run lint-structure && npm run check-links",
     "lint": "markdownlint 'src/**/*.md' --ignore src/appendices/appendices_draft.md",
+    "lint-structure": "node scripts/check-tool-blocks.js && node scripts/check-manuscript-guardrails.js docs",
     "check-links": "markdown-link-check -q -p src/chapters/*.md && markdown-link-check -q -p src/appendices/appendix-*.md && markdown-link-check -q -p src/introduction/index.md && markdown-link-check -q -p src/afterword/index.md && markdown-link-check -q -p docs/afterword/index.md",
     "deploy": "gh-pages -d docs"
   },


### PR DESCRIPTION
Fixes #194

## 変更内容
- 第4章: 閉包演算の説明を修正（^=推移閉包、*=反射推移閉包）し、例コメントも整合。
- 第4章/第8章: Alloy例の `u can read/access e` を除去し、構文として成立する形へ修正（第8章は擬似記法へ変更）。
- `npm test` に構造lint経路を追加（`lint-structure`: `check-tool-blocks` + `check-manuscript-guardrails`）。

## 検証
- `npm test`
