### PR TITLE
Fix #199: 第4章のnext未定義修正 + check-tool-blocks強化

### DIFF
--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -1401,6 +1401,7 @@ check GroupAccessControl for 4
 【ツール準拠（そのまま動く）】
 ```alloy
 sig Time {}
+open util/ordering[Time]
 
 sig User {
     active: set Time

--- a/scripts/check-tool-blocks.js
+++ b/scripts/check-tool-blocks.js
@@ -9,6 +9,7 @@ const ELLIPSIS_PATTERNS = ['...', '…'];
 const ALLOY_ENGLISH_INFIX_PATTERN = /\b\w+\s+can\s+(access|read)\s+\w+\b/;
 const ALLOY_ORDERING_OPEN_PATTERN = /\bopen\s+util\/ordering\s*\[/;
 const ALLOY_NEXT_DEFINITION_PATTERN = /\bnext\s*[:=]/;
+const ALLOY_NEXT_USAGE_PATTERN = /(\.next\b|(\^|\*)(\s*~)?\s*next\b|~\s*next\b)/;
 
 function getTrackedMarkdownFiles() {
   let out;
@@ -102,7 +103,7 @@ function checkFile(filePath) {
           if (alloyEnglishInfixLine === null && ALLOY_ENGLISH_INFIX_PATTERN.test(line)) {
             alloyEnglishInfixLine = fenceEndLine;
           }
-          if (alloyNextUsageLine === null && line.includes('.next')) {
+          if (alloyNextUsageLine === null && ALLOY_NEXT_USAGE_PATTERN.test(line)) {
             alloyNextUsageLine = fenceEndLine;
           }
         }
@@ -133,7 +134,7 @@ function checkFile(filePath) {
       errors.push({
         line: alloyNextUsageLine + 1,
         message:
-          `${TOOL_LABEL} のAlloyコードブロック内で ".next" を使用していますが、` +
+          `${TOOL_LABEL} のAlloyコードブロック内で next（例: .next / ^next / *next / ~next）を使用していますが、` +
           '`open util/ordering[...]` も `next:` 定義も見つかりません。ブロック単体で成立するよう補ってください',
       });
     }

--- a/src/chapters/chapter04.md
+++ b/src/chapters/chapter04.md
@@ -1366,6 +1366,7 @@ check GroupAccessControl for 4
 【ツール準拠（そのまま動く）】
 ```alloy
 sig Time {}
+open util/ordering[Time]
 
 sig User {
     active: set Time


### PR DESCRIPTION
Fixes #199

## 変更内容
- 第4章（docs/src）「時間的制約の発見と対処」直下のツール準拠Alloyブロックに `open util/ordering[Time]` を追加し、`^next`/`*next`/`^~next` 等が未定義にならないよう修正。
- `scripts/check-tool-blocks.js` の next 利用検出を `.next` だけでなく `^next`, `*next`, `~next`, `^~next`, `*~next` 等も拾うよう拡張。

## 検証
- `npm test`
