### PR TITLE
Chore: tool-blockガードのメッセージ改善

### DIFF
--- a/scripts/check-tool-blocks.js
+++ b/scripts/check-tool-blocks.js
@@ -209,7 +209,7 @@ function checkFile(filePath) {
     errors.push({
       line: sawToolLabelInFile.line,
       message:
-        'ツール準拠ラベルが見つかりましたが、ツールブロックとして解釈できませんでした。' +
+        `ツール準拠ラベル（${sawToolLabelInFile.label}）が見つかりましたが、ツールブロックとして解釈できませんでした。` +
         'ラベルは単独行で置き、直後にコードフェンス（```）を置いてください',
     });
   }


### PR DESCRIPTION
PR #208 のレビューコメント（guardの `label` 未使用）への追従です。

## 変更点
- `scripts/check-tool-blocks.js` の「検出ゼロ」ガードのエラーメッセージに、検出したラベル表記（【】/〖〗）を含めるようにしました。

## 確認
- `npm test`
