### PR TITLE
Clarify English introduction part payoffs

### DIFF
--- a/docs/en/introduction/index.md
+++ b/docs/en/introduction/index.md
@@ -59,22 +59,26 @@ The notation is introduced carefully, so advanced mathematics is not required.
 
 ## How the Book Is Organized
 
-The book is organized into four parts and thirteen chapters:
+The book is organized into four parts and thirteen chapters. Each part is meant
+to help you make a different kind of engineering decision:
 
 **Part I: Foundations (Chapters 1-3)**  
-Why formal methods matter, where informal reasoning breaks down, and what it
-means to write a precise specification
+Understand where informal reasoning breaks down, what counts as a precise
+specification, and why that distinction matters before tools enter the picture.
 
 **Part II: Methods (Chapters 4-7)**  
-Representative specification approaches, including Alloy, Z notation, CSP, and
-TLA+
+Compare representative specification styles such as Alloy, Z notation, CSP, and
+TLA+ so you can choose the notation that exposes the risk or behavior you need
+to reason about.
 
 **Part III: Verification (Chapters 8-10)**  
-How properties are checked, proved, and connected to program behavior
+Learn how to interpret counterexamples, proofs, and verification obligations,
+and when checking, proving, or program verification is the right level of
+assurance.
 
 **Part IV: Practice (Chapters 11-13)**  
-How formal methods fit into development processes, toolchains, and case-study
-based engineering decisions
+Decide how formal methods fit into development processes, toolchains, and
+organizational rollout without treating adoption as an all-or-nothing change.
 
 ## How to Read This Book
 

--- a/src/en/introduction/index.md
+++ b/src/en/introduction/index.md
@@ -52,22 +52,26 @@ The notation is introduced carefully, so advanced mathematics is not required.
 
 ## How the Book Is Organized
 
-The book is organized into four parts and thirteen chapters:
+The book is organized into four parts and thirteen chapters. Each part is meant
+to help you make a different kind of engineering decision:
 
 **Part I: Foundations (Chapters 1-3)**  
-Why formal methods matter, where informal reasoning breaks down, and what it
-means to write a precise specification
+Understand where informal reasoning breaks down, what counts as a precise
+specification, and why that distinction matters before tools enter the picture.
 
 **Part II: Methods (Chapters 4-7)**  
-Representative specification approaches, including Alloy, Z notation, CSP, and
-TLA+
+Compare representative specification styles such as Alloy, Z notation, CSP, and
+TLA+ so you can choose the notation that exposes the risk or behavior you need
+to reason about.
 
 **Part III: Verification (Chapters 8-10)**  
-How properties are checked, proved, and connected to program behavior
+Learn how to interpret counterexamples, proofs, and verification obligations,
+and when checking, proving, or program verification is the right level of
+assurance.
 
 **Part IV: Practice (Chapters 11-13)**  
-How formal methods fit into development processes, toolchains, and case-study
-based engineering decisions
+Decide how formal methods fit into development processes, toolchains, and
+organizational rollout without treating adoption as an all-or-nothing change.
 
 ## How to Read This Book
 


### PR DESCRIPTION
## Summary
- rewrite the English introduction part overview so each part states the engineering decision or payoff it helps readers reach
- move the section from structure-only wording to reader-facing guidance
- regenerate `docs/en/introduction/index.md`

## Validation
- npx markdownlint src/en/introduction/index.md
- npm run build:en
- NODE_PATH=/home/devuser/work/CodeX/formal-methods-book/node_modules npm test