### PR TITLE
[codex] Rename PR link label on top page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -120,7 +120,7 @@ source_path: "src/ja/index.md"
 
 - 公開ページ: [GitHub Pages](https://itdojp.github.io/formal-methods-book/)
 - リポジトリ: [GitHub]({{ repo_url }})
-- 更新確認先: [コミット履歴]({{ repo_url }}/commits/{{ repo_branch }}/)、[Pull Requests]({{ repo_url }}/pulls)
+- 更新確認先: [コミット履歴]({{ repo_url }}/commits/{{ repo_branch }}/)、[PR 一覧]({{ repo_url }}/pulls)
 - 付録Eは一次情報や関連資料の入口、付録Fは AI支援併用時の注意点の入口として使ってください。
 
 ## ライセンス

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -113,7 +113,7 @@
 
 - 公開ページ: [GitHub Pages](https://itdojp.github.io/formal-methods-book/)
 - リポジトリ: [GitHub]({{ repo_url }})
-- 更新確認先: [コミット履歴]({{ repo_url }}/commits/{{ repo_branch }}/)、[Pull Requests]({{ repo_url }}/pulls)
+- 更新確認先: [コミット履歴]({{ repo_url }}/commits/{{ repo_branch }}/)、[PR 一覧]({{ repo_url }}/pulls)
 - 付録Eは一次情報や関連資料の入口、付録Fは AI支援併用時の注意点の入口として使ってください。
 
 ## ライセンス


### PR DESCRIPTION
what changed
- renamed the top-page update link label from `Pull Requests` to `PR 一覧`

why it changed
- other book top pages have been standardized on `PR 一覧`
- this keeps update guidance consistent across the catalog

impact
- readers get a clearer and more consistent label for change tracking

validation
- `git diff --check`
- `npm run build`
- `npm test`
