### PR TITLE
fix: resolve mobile horizontal overflow

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -192,7 +192,7 @@ a:hover {
     display: flex;
     align-items: center;
     gap: 1rem;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
 }
 

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -166,6 +166,8 @@ a:hover {
 .book-layout {
     display: flex;
     min-height: 100vh;
+    min-width: 0;
+    width: 100%;
 }
 
 /* Header */
@@ -174,6 +176,8 @@ a:hover {
     top: 0;
     left: 0;
     right: 0;
+    max-width: 100vw;
+    min-width: 0;
     height: var(--header-height);
     background: var(--bg-primary);
     border-bottom: 1px solid var(--border-color);
@@ -188,13 +192,15 @@ a:hover {
     display: flex;
     align-items: center;
     gap: 1rem;
-    flex-shrink: 0;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .header-center {
     flex: 1;
     display: flex;
     justify-content: center;
+    min-width: 0;
 }
 
 .header-right {
@@ -202,6 +208,7 @@ a:hover {
     align-items: center;
     gap: 0.75rem;
     flex-shrink: 0;
+    min-width: 0;
 }
 
 .language-switcher {
@@ -229,12 +236,17 @@ a:hover {
 .header-title {
     text-decoration: none;
     color: var(--text-primary);
+    min-width: 0;
+    overflow: hidden;
 }
 
 .header-title h1 {
     margin: 0;
     font-size: 1.25rem;
     font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Sidebar */
@@ -349,12 +361,15 @@ a:hover {
     margin-left: var(--sidebar-width);
     margin-top: var(--header-height);
     min-height: calc(100vh - var(--header-height));
+    min-width: 0;
 }
 
 .book-content {
     max-width: var(--content-max-width);
+    width: 100%;
     margin: 0 auto;
     padding: 2rem 3rem;
+    min-width: 0;
 }
 
 .page-content {
@@ -362,6 +377,13 @@ a:hover {
     border-radius: 8px;
     padding: 2rem;
     box-shadow: var(--shadow-sm);
+    max-width: 100%;
+    min-width: 0;
+    overflow-wrap: break-word;
+}
+
+.page-content a {
+    overflow-wrap: anywhere;
 }
 
 /* Search */

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -5,8 +5,16 @@
 
 /* Hidden checkbox for state management */
 .sidebar-toggle-checkbox {
-  position: absolute;
-  left: -9999px;
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
   opacity: 0;
 }
 

--- a/docs/assets/css/syntax-highlighting.css
+++ b/docs/assets/css/syntax-highlighting.css
@@ -9,6 +9,8 @@ pre {
     overflow-x: auto;
     margin: 1.5rem 0;
     position: relative;
+    max-width: 100%;
+    min-width: 0;
 }
 
 code {
@@ -29,6 +31,8 @@ code {
 /* Line Numbers */
 .highlight {
     position: relative;
+    max-width: 100%;
+    min-width: 0;
 }
 
 .highlight pre {
@@ -179,6 +183,8 @@ pre[data-lang]::before {
 /* Copy Button */
 .code-block-wrapper {
     position: relative;
+    max-width: 100%;
+    min-width: 0;
 }
 
 .copy-button {


### PR DESCRIPTION
## Summary

- constrain the fixed header and flex layout so mobile widths can shrink without expanding the page viewport
- add safe wrapping for long links in page content
- keep code/highlight wrappers within the content width while preserving horizontal scrolling inside code blocks
- replace the off-screen checkbox positioning with clipped visually-hidden positioning so the sidebar toggle does not appear as an overflow offender

Closes #291
Related: itdojp/it-engineer-knowledge-architecture#117

## Validation

- `git diff --check`
- `npm run build:all`
- `npm run qa:bilingual`
- `node scripts/check-manuscript-guardrails.js docs`
- `npm test`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-textlint.js docs --fail-on error`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-links.js docs`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-layout-risk.js docs --fail-on error --output /home/devuser/work/CodeX/booksB/.codex-local/tmp/formal-layout-risk-overflow.json`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-markdown-structure.js docs --fail-on error --output /home/devuser/work/CodeX/booksB/.codex-local/tmp/formal-markdown-structure-overflow.json` (existing warnings only; no errors)
- `bundle exec jekyll build --config docs/_config.yml --source docs --layouts docs/_layouts --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/formal-overflow-server-before/formal-methods-book --baseurl /formal-methods-book`
- Local Playwright overflow smoke for `/`, `/chapters/chapter01/`, `/chapters/chapter07/`, `/chapters/chapter13/` on Chromium/Pixel 7 and WebKit/iPhone 13: all 8 checks reported `overflow=0`

## Notes

- `npm ci` still reports existing dependency audit findings; this PR does not change dependency manifests.