### PR TITLE
Fix mobile sidebar overlap

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -57,7 +57,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and portrait tablet widths. The checked/open rule below is
+     * more specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary

- Fixes the mobile/tablet portrait sidebar overlap for the published Formal Methods book layout.
- Keeps the closed drawer state off-canvas at `<=1024px` even though `main.css` imports `mobile-responsive.css` before the later desktop `.book-sidebar { transform: translateX(0); }` rule.
- Preserves the existing checked/open rule so the standard menu button still opens the TOC drawer.

## Root cause

`main.css` imports `mobile-responsive.css` before it declares the default desktop sidebar transform. On mobile/tablet widths the layout removes the main-content left margin, but the later desktop `transform: translateX(0)` could override the mobile closed-drawer `transform: translateX(-100%)`, leaving the fixed sidebar painted over the article.

This PR makes the mobile closed-drawer transform important. The checked/open selector already uses a more specific important rule, so the drawer still opens normally when the menu checkbox is toggled.

## Verification

- `npm ci`
- `npm test`
- `npm run build:all`
- `BUNDLE_GEMFILE=docs/Gemfile BUNDLE_PATH=.codex-local/bundle BUNDLE_APP_CONFIG=.codex-local/bundle-config bundle install`
- `BUNDLE_GEMFILE=docs/Gemfile BUNDLE_PATH=.codex-local/bundle BUNDLE_APP_CONFIG=.codex-local/bundle-config bundle exec jekyll build --source docs --destination .codex-local/site --trace`
- `git diff --check`
- Local Jekyll build served at `/formal-methods-book/`; Pages visual checker over 2 pages × 5 viewports passed:
  - `phone480`, `tablet` (768px), `tablet820`, `laptop1024`, `desktop`
  - result: `books=1 pages=10 ok=10 warn=0 fail=0`
- Direct Playwright probe over `/` and `/chapters/chapter01/` confirmed:
  - 480/768/820/1024px: closed drawer is off-canvas (`right=0`), no sidebar/content overlap, toggle is visible, and clicking the menu opens the drawer at `left=0`.
  - 1280px desktop: sidebar remains visible and content starts after the sidebar.

Refs itdojp/it-engineer-knowledge-architecture#168.
