### PR TITLE
公開実体に合わせUX module設定を修正

### DIFF
--- a/book-config.en.json
+++ b/book-config.en.json
@@ -131,12 +131,12 @@
   "ux": {
     "profile": "C",
     "modules": {
-      "quickStart": false,
+      "quickStart": true,
       "readingGuide": true,
       "checklistPack": false,
       "troubleshootingFlow": false,
       "conceptMap": true,
-      "figureIndex": true,
+      "figureIndex": false,
       "legalNotice": false,
       "glossary": true
     }

--- a/book-config.ja.json
+++ b/book-config.ja.json
@@ -130,12 +130,12 @@
   "ux": {
     "profile": "C",
     "modules": {
-      "quickStart": false,
+      "quickStart": true,
       "readingGuide": true,
       "checklistPack": false,
       "troubleshootingFlow": false,
       "conceptMap": true,
-      "figureIndex": true,
+      "figureIndex": false,
       "legalNotice": false,
       "glossary": true
     }


### PR DESCRIPTION
## 概要

Closes #329

日本語・英語editionのUX flagsを公開Pagesのreader-facing実体へ合わせます。

- 付録Bの独立したツールセットアップ導線を `quickStart=true` として反映
- 専用の図表索引がないため `figureIndex=false` へ修正

## 検証

- npm ci（0 vulnerabilities、whatwg-encoding deprecation warningあり）
- npm run build:all
- npm test
- npm audit --audit-level=moderate
- git diff --check（tracked node_modulesをrestore後）

既存のtracked node_modules / template残骸は #320 の範囲であり、本PRへ混在させません。