### PR TITLE
chore: active workflowsをNode.js 24対応Actionへ更新

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -95,7 +95,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm run build:all
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build Jekyll site
         uses: actions/jekyll-build-pages@v1
@@ -47,10 +47,10 @@ jobs:
           destination: ./_site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./_site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Book QA: `configure-pages@v5`を`v6`へ更新
- Pages: `configure-pages@v5`→`v6`、`upload-pages-artifact@v4`→`v5`、`deploy-pages@v4`→`v5`
- bilingual build、Jekyll、permissions、artifact/Pages契約は維持
- active workflowのrepository-managed Node.js 20以前Actionを0件化

## Verification
- actionlint 1.7.12: PASS
- `npm ci`: PASS
- `npm audit`: 0 vulnerabilities
- `npm test`: PASS
- `npm run build:all`: PASS
- `bundle exec jekyll build`: PASS
- `git diff --check`: PASS
- 対象旧参照: 0 / 新参照: 4

## Separated debt
- 固定book-formatter revisionのnpm audit 16件は#332
- GitHubのdefault branch Dependabot通知16件と、canonical lockfileのnpm audit 0件の差異はtracked node_modules整理Issue #320へ証跡を追記

Closes #331
