### PR TITLE
Appendix E の Ben-Or 論文リンクを修正する

### DIFF
--- a/docs/appendices/appendix-e/index.md
+++ b/docs/appendices/appendix-e/index.md
@@ -269,7 +269,7 @@ source_path: "src/ja/appendices/appendix-e.md"
   - Fischer, Lynch, and Paterson, FLP：<https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf>
   - Dwork, Lynch, and Stockmeyer, partial synchrony：<https://groups.csail.mit.edu/tds/papers/Lynch/jacm88.pdf>
   - Chandra and Toueg, unreliable failure detectors：<https://www.cs.utexas.edu/~lorenzo/corsi/cs380d/papers/p225-chandra.pdf>
-  - Ben-Or, randomized asynchronous agreement：<https://www.cs.cornell.edu/courses/cs5414/2017fa/papers/p27-ben-or.pdf>
+  - Ben-Or, randomized asynchronous agreement（DOI: `10.1145/800221.806707`）：<https://cris.huji.ac.il/en/publications/another-advantage-of-free-choice-completely-asynchronous-agreemen/>
 
 ## 7) 産業事例（一次・準一次情報）
 

--- a/docs/en/appendices/appendix-e/index.md
+++ b/docs/en/appendices/appendix-e/index.md
@@ -208,7 +208,7 @@ As of January 2026, it reflects naming changes and current mainstream references
   - Fischer, Lynch, and Paterson, FLP: <https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf>
   - Dwork, Lynch, and Stockmeyer, partial synchrony: <https://groups.csail.mit.edu/tds/papers/Lynch/jacm88.pdf>
   - Chandra and Toueg, unreliable failure detectors: <https://www.cs.utexas.edu/~lorenzo/corsi/cs380d/papers/p225-chandra.pdf>
-  - Ben-Or, randomized asynchronous agreement: <https://www.cs.cornell.edu/courses/cs5414/2017fa/papers/p27-ben-or.pdf>
+  - Ben-Or, randomized asynchronous agreement (DOI: `10.1145/800221.806707`): <https://cris.huji.ac.il/en/publications/another-advantage-of-free-choice-completely-asynchronous-agreemen/>
 
 ## 7) Industrial Case Studies and Adoption Evidence
 

--- a/src/en/appendices/appendix-e.md
+++ b/src/en/appendices/appendix-e.md
@@ -204,7 +204,7 @@ As of January 2026, it reflects naming changes and current mainstream references
   - Fischer, Lynch, and Paterson, FLP: <https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf>
   - Dwork, Lynch, and Stockmeyer, partial synchrony: <https://groups.csail.mit.edu/tds/papers/Lynch/jacm88.pdf>
   - Chandra and Toueg, unreliable failure detectors: <https://www.cs.utexas.edu/~lorenzo/corsi/cs380d/papers/p225-chandra.pdf>
-  - Ben-Or, randomized asynchronous agreement: <https://www.cs.cornell.edu/courses/cs5414/2017fa/papers/p27-ben-or.pdf>
+  - Ben-Or, randomized asynchronous agreement (DOI: `10.1145/800221.806707`): <https://cris.huji.ac.il/en/publications/another-advantage-of-free-choice-completely-asynchronous-agreemen/>
 
 ## 7) Industrial Case Studies and Adoption Evidence
 

--- a/src/ja/appendices/appendix-e.md
+++ b/src/ja/appendices/appendix-e.md
@@ -262,7 +262,7 @@
   - Fischer, Lynch, and Paterson, FLP：<https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf>
   - Dwork, Lynch, and Stockmeyer, partial synchrony：<https://groups.csail.mit.edu/tds/papers/Lynch/jacm88.pdf>
   - Chandra and Toueg, unreliable failure detectors：<https://www.cs.utexas.edu/~lorenzo/corsi/cs380d/papers/p225-chandra.pdf>
-  - Ben-Or, randomized asynchronous agreement：<https://www.cs.cornell.edu/courses/cs5414/2017fa/papers/p27-ben-or.pdf>
+  - Ben-Or, randomized asynchronous agreement（DOI: `10.1145/800221.806707`）：<https://cris.huji.ac.il/en/publications/another-advantage-of-free-choice-completely-asynchronous-agreemen/>
 
 ## 7) 産業事例（一次・準一次情報）
 


### PR DESCRIPTION
## 概要

Appendix E の Ben-Or 論文参照を、timeoutする Cornell 講義サイトのPDFから、原著者所属機関（Hebrew University of Jerusalem）の研究成果レコードへ変更します。原論文の DOI `10.1145/800221.806707` も明記します。

Closes #338

## 変更

- JA/EN canonical sourceのURLとDOIを同期
- `npm run build:all` で公開docsを再生成
- 本文・形式手法例・依存関係には変更なし

## 検証

- [x] 代替URL HTTP 200
- [x] `npm run build:all`
- [x] `npm test`
- [x] `npm audit`（0 vulnerabilities）
- [x] `git diff --check`
