### PR TITLE
Appendix EのCZT外部リンクを更新

### DIFF
--- a/docs/appendices/appendix-e/index.md
+++ b/docs/appendices/appendix-e/index.md
@@ -71,7 +71,7 @@ Alloy、TLC、Apalache、Dafny は `pr-quick`、SPIN、NuSMV、CBMC、Quint は
 - 用途：状態ベース仕様（集合/関係/写像）を厳密に記述し、レビューや検証の基盤にする
 - 推奨読者：第5章（Z記法）
 - 一次情報（実装・ツール）：
-  - Community Z Tools (CZT)：<https://czt.sourceforge.net/>
+  - Community Z Tools (CZT) source repository：<https://github.com/community-z-users/czt>
   - SourceForge（CZTプロジェクト）：<https://sourceforge.net/projects/czt/>
 
 ### CSP

--- a/docs/assets/search-index.en.json
+++ b/docs/assets/search-index.en.json
@@ -13452,7 +13452,7 @@
       "chapter": "Appendix E: References and Further Reading Paths",
       "heading": "Z (Z notation)",
       "url": "/formal-methods-book/en/appendices/appendix-e/#z-z-notation",
-      "text": "Purpose: rigorously describing state-based specifications with sets, relations, and mappings so they can serve as a basis for review and verification Best after reading: Chapter 5, \"State-Based Specification — Fundamentals of Z Notation\" Primary sources (implementations and tools): Community Z Tools (CZT): SourceForge (CZT project):",
+      "text": "Purpose: rigorously describing state-based specifications with sets, relations, and mappings so they can serve as a basis for review and verification Best after reading: Chapter 5, \"State-Based Specification — Fundamentals of Z Notation\" Primary sources (implementations and tools): Community Z Tools (CZT) source repository: SourceForge (CZT project):",
       "aliases": []
     },
     {

--- a/docs/assets/search-index.en.json
+++ b/docs/assets/search-index.en.json
@@ -13337,7 +13337,7 @@
       "chapter": "Appendix E: References and Further Reading Paths",
       "heading": "Appendix E: References and Further Reading Paths",
       "url": "/formal-methods-book/en/appendices/appendix-e/#appendix-e-references-and-further-reading-paths",
-      "text": "Translation status: Partial. Reviewed against Japanese source commit 1fa89537a869 on 2026-07-16. Some content, headings, examples, tables, or references remain partially synchronized. Track the remaining work. This appendix is a reader-facing guide to primary sources for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next. As of January 2026, it reflects naming changes and current mainstream references such as Coq → Rocq, CVC4 → cvc5, the Alloy 6 series, and Apalache in the TLA+ ecosystem.",
+      "text": "Translation status: Partial. Reviewed against Japanese source commit 13be0b1e9858 on 2026-07-16. Some content, headings, examples, tables, or references remain partially synchronized. Track the remaining work. This appendix is a reader-facing guide to primary sources for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next. As of January 2026, it reflects naming changes and current mainstream references such as Coq → Rocq, CVC4 → cvc5, the Alloy 6 series, and Apalache in the TLA+ ecosystem.",
       "aliases": [
         "TLA Plus",
         "The Rocq Prover"

--- a/docs/assets/search-index.ja.json
+++ b/docs/assets/search-index.ja.json
@@ -14255,7 +14255,7 @@
       "chapter": "付録E：参考文献とWebリソース",
       "heading": "Z（Z記法）",
       "url": "/formal-methods-book/appendices/appendix-e/#zz記法",
-      "text": "用途：状態ベース仕様（集合/関係/写像）を厳密に記述し、レビューや検証の基盤にする 推奨読者：第5章（Z記法） 一次情報（実装・ツール）： Community Z Tools (CZT)： SourceForge（CZTプロジェクト）：",
+      "text": "用途：状態ベース仕様（集合/関係/写像）を厳密に記述し、レビューや検証の基盤にする 推奨読者：第5章（Z記法） 一次情報（実装・ツール）： Community Z Tools (CZT) source repository： SourceForge（CZTプロジェクト）：",
       "aliases": []
     },
     {

--- a/docs/en/appendices/appendix-e/index.md
+++ b/docs/en/appendices/appendix-e/index.md
@@ -77,7 +77,7 @@ environment, or result for it.
 - Purpose: rigorously describing state-based specifications with sets, relations, and mappings so they can serve as a basis for review and verification
 - Best after reading: Chapter 5, "State-Based Specification — Fundamentals of Z Notation"
 - Primary sources (implementations and tools):
-  - Community Z Tools (`CZT`): <https://czt.sourceforge.net/>
+  - Community Z Tools (`CZT`) source repository: <https://github.com/community-z-users/czt>
   - `SourceForge` (`CZT` project): <https://sourceforge.net/projects/czt/>
 
 ### CSP

--- a/docs/en/appendices/appendix-e/index.md
+++ b/docs/en/appendices/appendix-e/index.md
@@ -6,14 +6,14 @@ locale: "en"
 lang: "en"
 source_path: "src/en/appendices/appendix-e.md"
 translation_status: "partial"
-translation_source_commit: "1fa89537a869c27faa1709c005ee129f2a8929a2"
+translation_source_commit: "13be0b1e9858fd7b1d3a0d44481cb389d0c6c36f"
 translation_reviewed_at: "2026-07-16"
-translation_tracking_issue: "https://github.com/itdojp/formal-methods-book/issues/328"
+translation_tracking_issue: "https://github.com/itdojp/formal-methods-book/issues/347"
 ---
 # Appendix E: References and Further Reading Paths
 
-> **Translation status: Partial.** Reviewed against Japanese source commit [`1fa89537a869`](https://github.com/itdojp/formal-methods-book/commit/1fa89537a869c27faa1709c005ee129f2a8929a2) on 2026-07-16.
-> Some content, headings, examples, tables, or references remain partially synchronized. [Track the remaining work](https://github.com/itdojp/formal-methods-book/issues/328).
+> **Translation status: Partial.** Reviewed against Japanese source commit [`13be0b1e9858`](https://github.com/itdojp/formal-methods-book/commit/13be0b1e9858fd7b1d3a0d44481cb389d0c6c36f) on 2026-07-16.
+> Some content, headings, examples, tables, or references remain partially synchronized. [Track the remaining work](https://github.com/itdojp/formal-methods-book/issues/347).
 
 This appendix is a **reader-facing guide to primary sources** for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next.  
 As of January 2026, it reflects naming changes and current mainstream references such as `Coq` → `Rocq`, `CVC4` → `cvc5`, the `Alloy 6` series, and `Apalache` in the TLA+ ecosystem.

--- a/docs/en/appendices/appendix-e/index.md
+++ b/docs/en/appendices/appendix-e/index.md
@@ -8,12 +8,12 @@ source_path: "src/en/appendices/appendix-e.md"
 translation_status: "partial"
 translation_source_commit: "13be0b1e9858fd7b1d3a0d44481cb389d0c6c36f"
 translation_reviewed_at: "2026-07-16"
-translation_tracking_issue: "https://github.com/itdojp/formal-methods-book/issues/347"
+translation_tracking_issue: "https://github.com/itdojp/formal-methods-book/issues/328"
 ---
 # Appendix E: References and Further Reading Paths
 
 > **Translation status: Partial.** Reviewed against Japanese source commit [`13be0b1e9858`](https://github.com/itdojp/formal-methods-book/commit/13be0b1e9858fd7b1d3a0d44481cb389d0c6c36f) on 2026-07-16.
-> Some content, headings, examples, tables, or references remain partially synchronized. [Track the remaining work](https://github.com/itdojp/formal-methods-book/issues/347).
+> Some content, headings, examples, tables, or references remain partially synchronized. [Track the remaining work](https://github.com/itdojp/formal-methods-book/issues/328).
 
 This appendix is a **reader-facing guide to primary sources** for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next.  
 As of January 2026, it reflects naming changes and current mainstream references such as `Coq` → `Rocq`, `CVC4` → `cvc5`, the `Alloy 6` series, and `Apalache` in the TLA+ ecosystem.

--- a/src/en/appendices/appendix-e.md
+++ b/src/en/appendices/appendix-e.md
@@ -62,7 +62,7 @@ environment, or result for it.
 - Purpose: rigorously describing state-based specifications with sets, relations, and mappings so they can serve as a basis for review and verification
 - Best after reading: Chapter 5, "State-Based Specification — Fundamentals of Z Notation"
 - Primary sources (implementations and tools):
-  - Community Z Tools (`CZT`): <https://czt.sourceforge.net/>
+  - Community Z Tools (`CZT`) source repository: <https://github.com/community-z-users/czt>
   - `SourceForge` (`CZT` project): <https://sourceforge.net/projects/czt/>
 
 ### CSP

--- a/src/ja/appendices/appendix-e.md
+++ b/src/ja/appendices/appendix-e.md
@@ -63,7 +63,7 @@ Alloy、TLC、Apalache、Dafny は `pr-quick`、SPIN、NuSMV、CBMC、Quint は
 - 用途：状態ベース仕様（集合/関係/写像）を厳密に記述し、レビューや検証の基盤にする
 - 推奨読者：第5章（Z記法）
 - 一次情報（実装・ツール）：
-  - Community Z Tools (CZT)：<https://czt.sourceforge.net/>
+  - Community Z Tools (CZT) source repository：<https://github.com/community-z-users/czt>
   - SourceForge（CZTプロジェクト）：<https://sourceforge.net/projects/czt/>
 
 ### CSP

--- a/translation-status.json
+++ b/translation-status.json
@@ -75,8 +75,8 @@
       "translation_sha256": "6323b36a33acd88bd1452256eb5c7a836e8cc611fddbce3004571b82a9779442",
       "status": "partial",
       "reviewed_at": "2026-07-16",
-      "tracking_issue": "https://github.com/itdojp/formal-methods-book/issues/347",
-      "notes": "CZT primary-source links were re-reviewed in both editions; heading level/order differs; 54 Japanese external reference link(s) are absent from English"
+      "tracking_issue": "https://github.com/itdojp/formal-methods-book/issues/328",
+      "notes": "heading level/order differs; 54 Japanese external reference link(s) are absent from English"
     },
     "appendices/appendix-f.md": {
       "source_path": "src/ja/appendices/appendix-f.md",

--- a/translation-status.json
+++ b/translation-status.json
@@ -69,14 +69,14 @@
     "appendices/appendix-e.md": {
       "source_path": "src/ja/appendices/appendix-e.md",
       "translation_path": "src/en/appendices/appendix-e.md",
-      "source_commit": "1fa89537a869c27faa1709c005ee129f2a8929a2",
-      "translated_commit": "1fa89537a869c27faa1709c005ee129f2a8929a2",
-      "source_sha256": "3408c2d176e927ec819efba0975efe9b692f1e8466f953fc015ecf08749a9405",
-      "translation_sha256": "af61b5d64319b7c1b29119d65a6bd817deceeab1f7c9f334a722acd8cd6ac72e",
+      "source_commit": "13be0b1e9858fd7b1d3a0d44481cb389d0c6c36f",
+      "translated_commit": "13be0b1e9858fd7b1d3a0d44481cb389d0c6c36f",
+      "source_sha256": "51f06de7e6de95304da80ee2e270ea260055d673f12bf34a0f146713a815e496",
+      "translation_sha256": "6323b36a33acd88bd1452256eb5c7a836e8cc611fddbce3004571b82a9779442",
       "status": "partial",
       "reviewed_at": "2026-07-16",
-      "tracking_issue": "https://github.com/itdojp/formal-methods-book/issues/328",
-      "notes": "heading level/order differs; 54 Japanese external reference link(s) are absent from English"
+      "tracking_issue": "https://github.com/itdojp/formal-methods-book/issues/347",
+      "notes": "CZT primary-source links were re-reviewed in both editions; heading level/order differs; 54 Japanese external reference link(s) are absent from English"
     },
     "appendices/appendix-f.md": {
       "source_path": "src/ja/appendices/appendix-f.md",


### PR DESCRIPTION
## Summary

- replace the repeatedly unavailable `czt.sourceforge.net` Appendix E link with the maintained Community Z Tools source repository
- keep the reachable SourceForge project page as the distribution/project link
- regenerate JA/EN Pages sources and search indexes
- record a new bilingual translation checkpoint for the reviewed JA/EN link change

## Evidence

- `https://czt.sourceforge.net/`: HTTP 503 on repeated checks (2026-07-16)
- `https://github.com/community-z-users/czt`: HTTP 200; non-archived repository described as Community Z Tools
- `https://sourceforge.net/projects/czt/`: HTTP 200

## Verification

- `npm ci` (0 vulnerabilities; existing non-vulnerability `whatwg-encoding` deprecation only)
- `npm run build:all`
- `npm test`
- `npm audit`
- deterministic generated-doc drift check
- Jekyll build and JA/EN Appendix E marker smoke
- `git diff --check`

## Merge requirement

Please use a regular merge commit rather than squash merge so translation checkpoint `13be0b1e9858fd7b1d3a0d44481cb389d0c6c36f` remains reachable from `main`.

Closes #347
