### PR TITLE
fix: pin the SPIN CLI documentation reference

### DIFF
--- a/docs/appendices/appendix-e/index.md
+++ b/docs/appendices/appendix-e/index.md
@@ -99,7 +99,7 @@ Alloy、TLC、Apalache、Dafny は `pr-quick`、SPIN、NuSMV、CBMC、Quint、PR
 - 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査）
 - 一次情報：
   - 公式（spinroot）：<https://spinroot.com/spin/whatispin.html>
-  - 固定版SPIN CLI man page（`-search`等のoption）：<https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
+  - 固定版SPIN CLI man page（`-search`等のオプション）：<https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
 
 ### NuSMV / nuXmv
 

--- a/docs/appendices/appendix-e/index.md
+++ b/docs/appendices/appendix-e/index.md
@@ -99,7 +99,7 @@ Alloy、TLC、Apalache、Dafny は `pr-quick`、SPIN、NuSMV、CBMC、Quint、PR
 - 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査）
 - 一次情報：
   - 公式（spinroot）：<https://spinroot.com/spin/whatispin.html>
-  - SPIN Quick Reference（探索方式、weak fairness、bitstate hashing）：<https://spinroot.com/spin/Man/Quick.html>
+  - 固定版SPIN CLI man page（`-search`等のoption）：<https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
 
 ### NuSMV / nuXmv
 

--- a/docs/assets/search-index.en.json
+++ b/docs/assets/search-index.en.json
@@ -13830,7 +13830,7 @@
       "chapter": "Appendix E: References and Further Reading Paths",
       "heading": "Appendix E: References and Further Reading Paths",
       "url": "/formal-methods-book/en/appendices/appendix-e/#appendix-e-references-and-further-reading-paths",
-      "text": "Translation status: Partial. Reviewed against Japanese source commit abf0ec3d6e65 on 2026-07-16. Some content, headings, examples, tables, or references remain partially synchronized. Track the remaining work. This appendix is a reader-facing guide to primary sources for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next. As of July 2026, it reflects naming changes and current mainstream references such as Coq → Rocq, CVC4 → cvc5, the Alloy 6 series, and Apalache in the TLA+ ecosystem.",
+      "text": "Translation status: Partial. Reviewed against Japanese source commit 933055b73cec on 2026-07-19. Some content, headings, examples, tables, or references remain partially synchronized. Track the remaining work. This appendix is a reader-facing guide to primary sources for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next. As of July 2026, it reflects naming changes and current mainstream references such as Coq → Rocq, CVC4 → cvc5, the Alloy 6 series, and Apalache in the TLA+ ecosystem.",
       "aliases": [
         "TLA Plus",
         "The Rocq Prover"
@@ -14002,12 +14002,10 @@
       "chapter": "Appendix E: References and Further Reading Paths",
       "heading": "SPIN (Promela)",
       "url": "/formal-methods-book/en/appendices/appendix-e/#spin-promela",
-      "text": "Purpose: explicit-state model checking of concurrent systems written in Promela, including counterexample traces; distinguish full-state search from approximate modes such as bitstate hashing Best after reading: Chapter 6, \"Process-Centric Specification — Concurrency with CSP\"; Chapter 8, \"Introduction to Model Checking\" Primary sources: Official page (spinroot): SPIN Quick Reference (search, weak fairness, and bitstate hashing):",
+      "text": "Purpose: explicit-state model checking of concurrent systems written in Promela, including counterexample traces; distinguish full-state search from approximate modes such as bitstate hashing Best after reading: Chapter 6, \"Process-Centric Specification — Concurrency with CSP\"; Chapter 8, \"Introduction to Model Checking\" Primary sources: Official page (spinroot): Pinned SPIN CLI manual source (-search and related options):",
       "aliases": [
         "模型検査",
-        "モデル検査",
-        "WF",
-        "弱公平性"
+        "モデル検査"
       ]
     },
     {

--- a/docs/assets/search-index.en.json
+++ b/docs/assets/search-index.en.json
@@ -13830,7 +13830,7 @@
       "chapter": "Appendix E: References and Further Reading Paths",
       "heading": "Appendix E: References and Further Reading Paths",
       "url": "/formal-methods-book/en/appendices/appendix-e/#appendix-e-references-and-further-reading-paths",
-      "text": "Translation status: Partial. Reviewed against Japanese source commit 933055b73cec on 2026-07-19. Some content, headings, examples, tables, or references remain partially synchronized. Track the remaining work. This appendix is a reader-facing guide to primary sources for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next. As of July 2026, it reflects naming changes and current mainstream references such as Coq → Rocq, CVC4 → cvc5, the Alloy 6 series, and Apalache in the TLA+ ecosystem.",
+      "text": "Translation status: Partial. Reviewed against Japanese source commit 269d1c49b552 on 2026-07-19. Some content, headings, examples, tables, or references remain partially synchronized. Track the remaining work. This appendix is a reader-facing guide to primary sources for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next. As of July 2026, it reflects naming changes and current mainstream references such as Coq → Rocq, CVC4 → cvc5, the Alloy 6 series, and Apalache in the TLA+ ecosystem.",
       "aliases": [
         "TLA Plus",
         "The Rocq Prover"

--- a/docs/assets/search-index.ja.json
+++ b/docs/assets/search-index.ja.json
@@ -14803,7 +14803,7 @@
       "chapter": "付録E：参考文献とWebリソース",
       "heading": "SPIN（Promela）",
       "url": "/formal-methods-book/appendices/appendix-e/#spinpromela",
-      "text": "用途：並行システムの明示的状態模型検査（Promela）と反例トレース。full-state search と bitstate hashing などの近似モードを区別する。 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査） 一次情報： 公式（spinroot）： 固定版SPIN CLI man page（-search等のoption）：",
+      "text": "用途：並行システムの明示的状態模型検査（Promela）と反例トレース。full-state search と bitstate hashing などの近似モードを区別する。 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査） 一次情報： 公式（spinroot）： 固定版SPIN CLI man page（-search等のオプション）：",
       "aliases": [
         "モデル検査",
         "model checking"

--- a/docs/assets/search-index.ja.json
+++ b/docs/assets/search-index.ja.json
@@ -14803,12 +14803,10 @@
       "chapter": "付録E：参考文献とWebリソース",
       "heading": "SPIN（Promela）",
       "url": "/formal-methods-book/appendices/appendix-e/#spinpromela",
-      "text": "用途：並行システムの明示的状態模型検査（Promela）と反例トレース。full-state search と bitstate hashing などの近似モードを区別する。 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査） 一次情報： 公式（spinroot）： SPIN Quick Reference（探索方式、weak fairness、bitstate hashing）：",
+      "text": "用途：並行システムの明示的状態模型検査（Promela）と反例トレース。full-state search と bitstate hashing などの近似モードを区別する。 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査） 一次情報： 公式（spinroot）： 固定版SPIN CLI man page（-search等のoption）：",
       "aliases": [
         "モデル検査",
-        "model checking",
-        "WF",
-        "弱公平性"
+        "model checking"
       ]
     },
     {

--- a/docs/en/appendices/appendix-e/index.md
+++ b/docs/en/appendices/appendix-e/index.md
@@ -6,13 +6,13 @@ locale: "en"
 lang: "en"
 source_path: "src/en/appendices/appendix-e.md"
 translation_status: "partial"
-translation_source_commit: "933055b73cece5a69931e07d8ca8413ddae18fcf"
+translation_source_commit: "269d1c49b552ec49cc7867361aa28239c82d0885"
 translation_reviewed_at: "2026-07-19"
 translation_tracking_issue: "https://github.com/itdojp/formal-methods-book/issues/328"
 ---
 # Appendix E: References and Further Reading Paths
 
-> **Translation status: Partial.** Reviewed against Japanese source commit [`933055b73cec`](https://github.com/itdojp/formal-methods-book/commit/933055b73cece5a69931e07d8ca8413ddae18fcf) on 2026-07-19.
+> **Translation status: Partial.** Reviewed against Japanese source commit [`269d1c49b552`](https://github.com/itdojp/formal-methods-book/commit/269d1c49b552ec49cc7867361aa28239c82d0885) on 2026-07-19.
 > Some content, headings, examples, tables, or references remain partially synchronized. [Track the remaining work](https://github.com/itdojp/formal-methods-book/issues/328).
 
 This appendix is a **reader-facing guide to primary sources** for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next.  

--- a/docs/en/appendices/appendix-e/index.md
+++ b/docs/en/appendices/appendix-e/index.md
@@ -6,13 +6,13 @@ locale: "en"
 lang: "en"
 source_path: "src/en/appendices/appendix-e.md"
 translation_status: "partial"
-translation_source_commit: "abf0ec3d6e6509ed53da0e7b7e10fc59d8dfebd4"
-translation_reviewed_at: "2026-07-16"
+translation_source_commit: "933055b73cece5a69931e07d8ca8413ddae18fcf"
+translation_reviewed_at: "2026-07-19"
 translation_tracking_issue: "https://github.com/itdojp/formal-methods-book/issues/328"
 ---
 # Appendix E: References and Further Reading Paths
 
-> **Translation status: Partial.** Reviewed against Japanese source commit [`abf0ec3d6e65`](https://github.com/itdojp/formal-methods-book/commit/abf0ec3d6e6509ed53da0e7b7e10fc59d8dfebd4) on 2026-07-16.
+> **Translation status: Partial.** Reviewed against Japanese source commit [`933055b73cec`](https://github.com/itdojp/formal-methods-book/commit/933055b73cece5a69931e07d8ca8413ddae18fcf) on 2026-07-19.
 > Some content, headings, examples, tables, or references remain partially synchronized. [Track the remaining work](https://github.com/itdojp/formal-methods-book/issues/328).
 
 This appendix is a **reader-facing guide to primary sources** for the methods, tools, and case studies introduced in the main text. Use it when you want to deepen a chapter, verify a claim against an official source, or decide which tool family to study next.  
@@ -103,7 +103,7 @@ environment, or result for it.
 - Best after reading: Chapter 6, "Process-Centric Specification — Concurrency with CSP"; Chapter 8, "Introduction to Model Checking"
 - Primary sources:
   - Official page (`spinroot`): <https://spinroot.com/spin/whatispin.html>
-  - SPIN Quick Reference (search, weak fairness, and bitstate hashing): <https://spinroot.com/spin/Man/Quick.html>
+  - Pinned SPIN CLI manual source (`-search` and related options): <https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
 
 ### NuSMV / nuXmv
 

--- a/scripts/check-guarantee-boundaries.js
+++ b/scripts/check-guarantee-boundaries.js
@@ -298,7 +298,7 @@ auditFile('glossary-terms.md', [
 
 const primarySourceUrls = [
   'https://lamport.azurewebsites.net/pubs/spec-book-chap.pdf',
-  'https://spinroot.com/spin/Man/Quick.html',
+  'https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1',
   'https://nuxmv.fbk.eu/downloads/nuxmv-user-manual.pdf',
   'https://diffblue.github.io/cbmc/background-concepts.html',
   'https://rocq-prover.org/doc/v9.0/refman/proofs/writing-proofs/proof-mode.html',

--- a/src/en/appendices/appendix-e.md
+++ b/src/en/appendices/appendix-e.md
@@ -88,7 +88,7 @@ environment, or result for it.
 - Best after reading: Chapter 6, "Process-Centric Specification — Concurrency with CSP"; Chapter 8, "Introduction to Model Checking"
 - Primary sources:
   - Official page (`spinroot`): <https://spinroot.com/spin/whatispin.html>
-  - SPIN Quick Reference (search, weak fairness, and bitstate hashing): <https://spinroot.com/spin/Man/Quick.html>
+  - Pinned SPIN CLI manual source (`-search` and related options): <https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
 
 ### NuSMV / nuXmv
 

--- a/src/ja/appendices/appendix-e.md
+++ b/src/ja/appendices/appendix-e.md
@@ -91,7 +91,7 @@ Alloy、TLC、Apalache、Dafny は `pr-quick`、SPIN、NuSMV、CBMC、Quint、PR
 - 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査）
 - 一次情報：
   - 公式（spinroot）：<https://spinroot.com/spin/whatispin.html>
-  - SPIN Quick Reference（探索方式、weak fairness、bitstate hashing）：<https://spinroot.com/spin/Man/Quick.html>
+  - 固定版SPIN CLI man page（`-search`等のoption）：<https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
 
 ### NuSMV / nuXmv
 

--- a/src/ja/appendices/appendix-e.md
+++ b/src/ja/appendices/appendix-e.md
@@ -91,7 +91,7 @@ Alloy、TLC、Apalache、Dafny は `pr-quick`、SPIN、NuSMV、CBMC、Quint、PR
 - 推奨読者：第6章（並行性の落とし穴）、第8章（模型検査）
 - 一次情報：
   - 公式（spinroot）：<https://spinroot.com/spin/whatispin.html>
-  - 固定版SPIN CLI man page（`-search`等のoption）：<https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
+  - 固定版SPIN CLI man page（`-search`等のオプション）：<https://github.com/nimble-code/Spin/blob/4883fbb1b1ef1f75fa9dda78efe1ad8910baf819/Man/spin.1>
 
 ### NuSMV / nuXmv
 

--- a/translation-status.json
+++ b/translation-status.json
@@ -76,7 +76,7 @@
       "status": "partial",
       "reviewed_at": "2026-07-19",
       "tracking_issue": "https://github.com/itdojp/formal-methods-book/issues/328",
-      "notes": "Issue #357 synchronized the pinned SPIN CLI documentation reference across JA/EN. The broader appendix remains partial for heading differences and Japanese-only external references tracked by #328."
+      "notes": "The RTLola/MonPoly/RV-Monitor primary-source comparison, selection rationale, version/provenance, assurance boundary, and prior references were semantically reviewed across JA/EN. Issue #357 synchronized the pinned SPIN CLI documentation reference. The broader appendix remains partial for heading differences and Japanese-only external references tracked by #328."
     },
     "appendices/appendix-f.md": {
       "source_path": "src/ja/appendices/appendix-f.md",

--- a/translation-status.json
+++ b/translation-status.json
@@ -69,14 +69,14 @@
     "appendices/appendix-e.md": {
       "source_path": "src/ja/appendices/appendix-e.md",
       "translation_path": "src/en/appendices/appendix-e.md",
-      "source_commit": "933055b73cece5a69931e07d8ca8413ddae18fcf",
-      "translated_commit": "933055b73cece5a69931e07d8ca8413ddae18fcf",
-      "source_sha256": "c35449c1ed3a81764830412530b0b326c7f7371e31edb0cda3a33071ef1d2774",
+      "source_commit": "269d1c49b552ec49cc7867361aa28239c82d0885",
+      "translated_commit": "269d1c49b552ec49cc7867361aa28239c82d0885",
+      "source_sha256": "decf8f5bbe2363a50be1fa3be339eed5301022a40e5f33209687da6ffa87b5ab",
       "translation_sha256": "2d74199b4b6db69af771fcfb101f6f503571ef4f891d393b20abab78c69838e4",
       "status": "partial",
       "reviewed_at": "2026-07-19",
       "tracking_issue": "https://github.com/itdojp/formal-methods-book/issues/328",
-      "notes": "The RTLola/MonPoly/RV-Monitor primary-source comparison, selection rationale, version/provenance, assurance boundary, and prior references were semantically reviewed across JA/EN. Issue #357 synchronized the pinned SPIN CLI documentation reference. The broader appendix remains partial for heading differences and Japanese-only external references tracked by #328."
+      "notes": "The RTLola/MonPoly/RV-Monitor primary-source comparison, selection rationale, version/provenance, assurance boundary, and prior references were semantically reviewed across JA/EN. Issue #357 synchronized the pinned SPIN CLI documentation reference and normalized the Japanese option label after review. The broader appendix remains partial for heading differences and Japanese-only external references tracked by #328."
     },
     "appendices/appendix-f.md": {
       "source_path": "src/ja/appendices/appendix-f.md",

--- a/translation-status.json
+++ b/translation-status.json
@@ -69,14 +69,14 @@
     "appendices/appendix-e.md": {
       "source_path": "src/ja/appendices/appendix-e.md",
       "translation_path": "src/en/appendices/appendix-e.md",
-      "source_commit": "abf0ec3d6e6509ed53da0e7b7e10fc59d8dfebd4",
-      "translated_commit": "abf0ec3d6e6509ed53da0e7b7e10fc59d8dfebd4",
-      "source_sha256": "a95f7ce4914e557c205e2809e4956992832735210b52988b73022882970c9f29",
-      "translation_sha256": "b9ea81c83728e94fd8f39a330611db44be03adc14830d62ca9dbb13f264d27f6",
+      "source_commit": "933055b73cece5a69931e07d8ca8413ddae18fcf",
+      "translated_commit": "933055b73cece5a69931e07d8ca8413ddae18fcf",
+      "source_sha256": "c35449c1ed3a81764830412530b0b326c7f7371e31edb0cda3a33071ef1d2774",
+      "translation_sha256": "2d74199b4b6db69af771fcfb101f6f503571ef4f891d393b20abab78c69838e4",
       "status": "partial",
-      "reviewed_at": "2026-07-16",
+      "reviewed_at": "2026-07-19",
       "tracking_issue": "https://github.com/itdojp/formal-methods-book/issues/328",
-      "notes": "The RTLola/MonPoly/RV-Monitor primary-source comparison, selection rationale, version/provenance, and assurance boundary plus prior references were semantically reviewed across JA/EN; the broader appendix still has heading differences and Japanese-only external references"
+      "notes": "Issue #357 synchronized the pinned SPIN CLI documentation reference across JA/EN. The broader appendix remains partial for heading differences and Japanese-only external references tracked by #328."
     },
     "appendices/appendix-f.md": {
       "source_path": "src/ja/appendices/appendix-f.md",


### PR DESCRIPTION
## 概要

- GitHub Actionsから2回連続でHTTP 415となったSPIN Quick Reference参照を置換
- `tools/tool-manifest.json`と同じ固定commit上の公式`Man/spin.1`へJA/ENを同期
- 外部リンク検査のignore追加は行わず、保証境界QAの一次情報markerも固定URLへ更新
- generated docs/search indexとAppendix E translation checkpointを更新し、既存のpartial理由とレビュー来歴を維持

## 検証

- JA/EN Appendix E個別link check
- `npm run build:all` + deterministic diff
- `npm test`
- `npm audit --omit=dev --omit=optional`（0 vulnerabilities）
- `npm run check:guarantees`
- `npm run test:bilingual-integrity`
- `npm run qa:bilingual`（既知partialのみ、stale 0）
- `npm run check:search-index`
- `git diff --check`

## 背景証跡

- #354 merge後main CI run 29704144364のattempt 1 / 2が、既存`spinroot.com/spin/Man/Quick.html`のHTTP 415で失敗
- 同URLの追加ignoreではなく、固定一次情報への置換で解消
- #355のRocq本文には未着手

Fixes #357
